### PR TITLE
feat: Add tracked pose publishing wrt odom

### DIFF
--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -329,11 +329,10 @@ void Node::PublishLocalTrajectoryData(const ::ros::TimerEvent& timer_event) {
       }
       if (node_options_.publish_tracked_pose_from_odom) {
         if (trajectory_data.trajectory_options.provide_odom_frame) {
-            Rigid3d odom_to_tracking = tracking_to_local;
             ::geometry_msgs::PoseStamped pose_msg;
             pose_msg.header.frame_id = trajectory_data.trajectory_options.odom_frame;
             pose_msg.header.stamp = stamped_transform.header.stamp;
-            pose_msg.pose = ToGeometryMsgPose(odom_to_tracking);
+            pose_msg.pose = ToGeometryMsgPose(tracking_to_local);
             odom_tracked_pose_publisher_.publish(pose_msg);
         } else {
           LOG(WARNING) << "Cannot publish tracked pose with respect to odom frame if odom frame is not being published";

--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -119,6 +119,11 @@ Node::Node(
         node_handle_.advertise<::geometry_msgs::PoseStamped>(
             kTrackedPoseTopic, kLatestOnlyPublisherQueueSize);
   }
+  if (node_options_.publish_tracked_pose_from_odom) {
+    odom_tracked_pose_publisher_ = 
+        node_handle_.advertise<::geometry_msgs::PoseStamped>(
+            kOdomTrackedPoseTopic, kLatestOnlyPublisherQueueSize);
+  }
   service_servers_.push_back(node_handle_.advertiseService(
       kSubmapQueryServiceName, &Node::HandleSubmapQuery, this));
   service_servers_.push_back(node_handle_.advertiseService(

--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -327,6 +327,18 @@ void Node::PublishLocalTrajectoryData(const ::ros::TimerEvent& timer_event) {
         pose_msg.pose = ToGeometryMsgPose(tracking_to_map);
         tracked_pose_publisher_.publish(pose_msg);
       }
+      if (node_options_.publish_tracked_pose_from_odom) {
+        if (trajectory_data.trajectory_options.provide_odom_frame) {
+            Rigid3d odom_to_tracking = tracking_to_local;
+            ::geometry_msgs::PoseStamped pose_msg;
+            pose_msg.header.frame_id = trajectory_data.trajectory_options.odom_frame;
+            pose_msg.header.stamp = stamped_transform.header.stamp;
+            pose_msg.pose = ToGeometryMsgPose(odom_to_tracking);
+            odom_tracked_pose_publisher_.publish(pose_msg);
+        } else {
+          LOG(WARNING) << "Cannot publish tracked pose with respect to odom frame if odom frame is not being published";
+        }
+      }
     }
   }
 }

--- a/cartographer_ros/cartographer_ros/node.h
+++ b/cartographer_ros/cartographer_ros/node.h
@@ -189,6 +189,7 @@ class Node {
   ::ros::Publisher landmark_poses_list_publisher_;
   ::ros::Publisher constraint_list_publisher_;
   ::ros::Publisher tracked_pose_publisher_;
+  ::ros::Publisher odom_tracked_pose_publisher_;
   // These ros::ServiceServers need to live for the lifetime of the node.
   std::vector<::ros::ServiceServer> service_servers_;
   ::ros::Publisher scan_matched_point_cloud_publisher_;

--- a/cartographer_ros/cartographer_ros/node_constants.h
+++ b/cartographer_ros/cartographer_ros/node_constants.h
@@ -35,6 +35,7 @@ constexpr char kOccupancyGridTopic[] = "map";
 constexpr char kScanMatchedPointCloudTopic[] = "scan_matched_points2";
 constexpr char kSubmapListTopic[] = "submap_list";
 constexpr char kTrackedPoseTopic[] = "tracked_pose";
+constexpr char kOdomTrackedPoseTopic[] = "odom_tracked_pose";
 constexpr char kSubmapQueryServiceName[] = "submap_query";
 constexpr char kTrajectoryQueryServiceName[] = "trajectory_query";
 constexpr char kStartTrajectoryServiceName[] = "start_trajectory";

--- a/cartographer_ros/cartographer_ros/node_options.cc
+++ b/cartographer_ros/cartographer_ros/node_options.cc
@@ -52,6 +52,10 @@ NodeOptions CreateNodeOptions(
     options.use_pose_extrapolator =
         lua_parameter_dictionary->GetBool("use_pose_extrapolator");
   }
+  if (lua_parameter_dictionary->HasKey("publish_tracked_pose_from_odom")) {
+    options.publish_tracked_pose_from_odom = 
+        lua_parameter_dictionary->GetBool("publish_tracked_pose_from_odom");
+  }
   return options;
 }
 

--- a/cartographer_ros/cartographer_ros/node_options.h
+++ b/cartographer_ros/cartographer_ros/node_options.h
@@ -38,6 +38,7 @@ struct NodeOptions {
   bool publish_to_tf = true;
   bool publish_tracked_pose = false;
   bool use_pose_extrapolator = true;
+  bool publish_tracked_pose_from_odom = false;
 };
 
 NodeOptions CreateNodeOptions(


### PR DESCRIPTION
Cartographer only publishes pose wrt `map` frame originally. This means if we have loop closure the pose estimates are not smooth and continuous.
This PR adds the functionality to publish smooth pose estimates with respect to the `odom` frame on the topic `/odom_tracked_pose` without the need for publishing the tfs.

To enable publishing of the smooth publishing pose, make the following changes to the options in the lua file.
1. Provide the `odom_frame`.
2. Set `provide_odom_frame = true`.
3. Set `publish_tracked_pose_from_odom = true`.

[cartogrpaher_odom_pose.webm](https://github.com/user-attachments/assets/3e8282af-3abf-4fe4-bd93-ff79e40fd401)

